### PR TITLE
Reassigns return of array concatenation back to original variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ async function getKeys(
 
   // check to see if there are more than 1000 keys
   if (keys.result_info && keys.result_info.cursor) {
-    keys.result.concat(
+    keys.result = keys.result.concat(
       await getKeys(
         { accountId, authEmail, authKey },
         namespace,


### PR DESCRIPTION
Saves result of concatenation. Previous functionality would return a list of key as long as the first window because the subsequent responses were never appended.

Testing: manually patched and tested